### PR TITLE
Fix relative date when at end of month

### DIFF
--- a/calendar
+++ b/calendar
@@ -2,8 +2,9 @@
 
 send_notification() {
 	TODAY=$(date '+%-d')
-	HEAD=$(cal "$1" | head -n1)
-	BODY=$(cal "$1" | tail -n7 | sed -z "s|$TODAY|<u><b>$TODAY</b></u>|1")
+	DATE="$(date -d "$(date +%Y-%m-01) $1" +%Y-%m-%d)"
+	HEAD=$(cal "$DATE" | head -n1)
+	BODY=$(cal "$DATE" | tail -n7 | sed -z "s|$TODAY|<u><b>$TODAY</b></u>|1")
 	FOOT="\n<i>       ~ calendar</i> 󰸗 "
 	dunstify -h string:x-canonical-private-synchronous:calendar \
 		"$HEAD" "$BODY$FOOT" -u NORMAL


### PR DESCRIPTION
Using the relative date format (+n months) starting from a day that isn't in the next month forces date to skip over that month. 
For example, on the 30th of September 2025 (today), going +5 months forward skips over February, displaying March instead, as September has 30 days while February only has 28 days.

This patch starts the relative date query from the first of each month instead of the current day to avoid this.