### PR TITLE
Avoid highlighting day of the month when irelevant

### DIFF
--- a/calendar
+++ b/calendar
@@ -4,6 +4,7 @@ send_notification() {
 	TODAY=$(date '+%-d')
 	HEAD=$(cal "$1" | head -n1)
 	BODY=$(cal "$1" | tail -n7 | sed -z "s|$TODAY|<u><b>$TODAY</b></u>|1")
+	[ "$1" != "+0 months" ] && TODAY='32'
 	FOOT="\n<i>       ~ calendar</i> 󰸗 "
 	dunstify -h string:x-canonical-private-synchronous:calendar \
 		"$HEAD" "$BODY$FOOT" -u NORMAL


### PR DESCRIPTION
The exact approach might need work, but this prevents the current day of the month from being highlighted when displaying months other than the current one.